### PR TITLE
Disable javascript when form field is disabled

### DIFF
--- a/Resources/public/js/rating.js
+++ b/Resources/public/js/rating.js
@@ -1,10 +1,16 @@
 $(function(){
     var labelWasClicked = function labelWasClicked(){
         var input = $(this).siblings().filter('input');
+        if (input.attr('disabled')) {
+            return;
+        }
         input.val($(this).attr('data-value'));
     }
-    
+
     var turnToStar = function turnToStar(){
+        if ($(this).find('input').attr('disabled')) {
+            return;
+        }
         var labels = $(this).find('div');
         labels.removeClass();
         labels.addClass('star');


### PR DESCRIPTION
Thanks for the cool bundle!

This should fix #4 when using the `disabled` option (read_only is deprecated from Symfony 2.8 onwards).